### PR TITLE
Fix record period order and bigint js response

### DIFF
--- a/app/src/pages/Player/components/PlayerRecordsWidget/PlayerRecordsWidget.jsx
+++ b/app/src/pages/Player/components/PlayerRecordsWidget/PlayerRecordsWidget.jsx
@@ -30,7 +30,11 @@ function PlayerRecordsWidget({ records, metric }) {
     return null;
   }
 
-  const filteredRecords = records.filter((r) => r.metric === metric);
+  const PERIOD_ORDER = ['day', 'week', 'month', 'year'];
+
+  const filteredRecords = records
+    .filter((r) => r.metric === metric)
+    .sort((a, b) => PERIOD_ORDER.indexOf(a.period) - PERIOD_ORDER.indexOf(b.period));
 
   return (
     <div className="player-records-widget">

--- a/server/src/api/modules/records/record.model.js
+++ b/server/src/api/modules/records/record.model.js
@@ -35,7 +35,13 @@ module.exports = (sequelize, DataTypes) => {
     },
     value: {
       type: DataTypes.BIGINT,
-      defaultValue: 0
+      defaultValue: 0,
+      get() {
+        // As experience (overall) can exceed the integer maximum of 2.147b,
+        // we have to store it into a BIGINT, however, sequelize returns bigints
+        // as strings, to counter that, we convert every bigint to a JS number
+        return parseInt(this.getDataValue('value'), 10);
+      }
     }
   };
 

--- a/server/src/api/modules/snapshots/snapshot.model.js
+++ b/server/src/api/modules/snapshots/snapshot.model.js
@@ -5,7 +5,16 @@ function buildDynamicSchema(DataTypes) {
 
   SKILLS.forEach(s => {
     obj[`${s}Rank`] = DataTypes.INTEGER;
-    obj[`${s}Experience`] = s === 'overall' ? DataTypes.BIGINT : DataTypes.INTEGER;
+
+    obj[`${s}Experience`] = {
+      type: s === 'overall' ? DataTypes.BIGINT : DataTypes.INTEGER,
+      get() {
+        // As experience (overall) can exceed the integer maximum of 2.147b,
+        // we have to store it into a BIGINT, however, sequelize returns bigints
+        // as strings, to counter that, we convert every bigint to a JS number
+        return parseInt(this.getDataValue(`${s}Experience`), 10);
+      }
+    };
   });
 
   return obj;


### PR DESCRIPTION
Fixes #29 

- Fixed player records period order (it's now day > week > month > year)
- Fixed bigints (in snapshots and records) being displayed as strings in the API response