### PR TITLE
Remove nginx image caching

### DIFF
--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,8 +1,3 @@
-map $sent_http_content_type $expires {
-    default     off;
-    ~image/     max;
-}
-
 server {
     listen 80;
     server_name wiseoldman.net;
@@ -19,8 +14,6 @@ server {
 server {
     listen 443 ssl;
     server_name  wiseoldman.net;
-    
-    expires $expires;
 
     ssl_certificate /etc/letsencrypt/live/wiseoldman.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/wiseoldman.net/privkey.pem;


### PR DESCRIPTION
I don't think the nginx image caching is necessary anymore since the cloudflare setup. So I'm removing it.

And also it messed the favicon for some reason.