### PR TITLE
Fix player type fetching

### DIFF
--- a/app/src/components/Dropdown/Dropdown.jsx
+++ b/app/src/components/Dropdown/Dropdown.jsx
@@ -1,17 +1,10 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Wrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
 import classNames from 'classnames';
 import './Dropdown.scss';
 
 function Dropdown({ options, align, onSelect, children }) {
-  function handleSelection(selectedLabel) {
-    onSelect(options.find(o => o.label === selectedLabel));
-  }
-
-  // Memoized callback
-  const onOptionSelected = useCallback(handleSelection, [options, onSelect]);
-
   const listClass = classNames({
     'dropdown-list': true,
     '-right': align === 'right',
@@ -19,13 +12,17 @@ function Dropdown({ options, align, onSelect, children }) {
   });
 
   return (
-    <Wrapper className="dropdown__container" onSelection={onOptionSelected}>
+    <Wrapper className="dropdown__container">
       <Button className="dropdown__toggle">{children}</Button>
       <Menu className={listClass}>
         {options &&
           options.map(option => {
             return (
-              <MenuItem key={option.label} className="dropdown-list__item">
+              <MenuItem
+                key={option.label}
+                className="dropdown-list__item"
+                onClick={() => onSelect(option)}
+              >
                 {option.label}
               </MenuItem>
             );

--- a/app/src/components/Notification/Notification.scss
+++ b/app/src/components/Notification/Notification.scss
@@ -24,6 +24,7 @@
     opacity: 0;
     transform: translateY(-200px);
     transition: 0.5s;
+    pointer-events: all;
 
     &.-visible {
       opacity: 1;

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -7,6 +7,7 @@ import Button from '../../components/Button';
 import Selector from '../../components/Selector';
 import Tabs from '../../components/Tabs';
 import LineChart from '../../components/LineChart';
+import Dropdown from '../../components/Dropdown';
 import PlayerInfo from './components/PlayerInfo';
 import PlayerStatsTable from './components/PlayerStatsTable';
 import PlayerDeltasTable from './components/PlayerDeltasTable';
@@ -23,6 +24,7 @@ import { getPlayerCompetitions } from '../../redux/selectors/competitions';
 import { getPlayerGroups } from '../../redux/selectors/groups';
 import { getChartData } from '../../redux/selectors/snapshots';
 import trackPlayerAction from '../../redux/modules/players/actions/track';
+import assertPlayerTypeAction from '../../redux/modules/players/actions/assertType';
 import fetchPlayerAction from '../../redux/modules/players/actions/fetch';
 import fetchDeltasAction from '../../redux/modules/deltas/actions/fetch';
 import fetchSnapshotsAction from '../../redux/modules/snapshots/actions/fetch';
@@ -41,6 +43,13 @@ const PERIOD_SELECTOR_OPTIONS = [
   { label: 'Week', value: 'week' },
   { label: 'Month', value: 'month' },
   { label: 'Year', value: 'year' }
+];
+
+const MENU_OPTIONS = [
+  {
+    label: 'Reasign player type',
+    value: 'assertType'
+  }
 ];
 
 function getMetricOptions() {
@@ -112,10 +121,17 @@ function Player() {
     setSelectedDeltasSkill((e && e.value) || null);
   };
 
+  const handleOptionSelected = async option => {
+    if (option.value === 'assertType') {
+      await dispatch(assertPlayerTypeAction(player.username, player.id));
+    }
+  };
+
   const onTabChanged = useCallback(handleTabChanged, []);
   const onDeltasPeriodSelected = useCallback(handleDeltasPeriodSelected, [setSelectedDeltasPeriod]);
   const onSkillsPeriodSelected = useCallback(handleDeltasSkillSelected, [setSelectedDeltasSkill]);
   const onUpdatedButtonClicked = useCallback(trackPlayer, [player]);
+  const onOptionSelected = useCallback(handleOptionSelected, [player]);
 
   // Fetch all player info on mount
   useEffect(fetchAll, [dispatch, id]);
@@ -135,6 +151,11 @@ function Player() {
         <div className="col">
           <PageHeader title={player.username} icon={getPlayerTypeIcon(player.type)}>
             <Button text="Update" onClick={onUpdatedButtonClicked} loading={isTracking} />
+            <Dropdown options={MENU_OPTIONS} onSelect={onOptionSelected}>
+              <button className="header__options-btn" type="button">
+                <img src="/img/icons/options.svg" alt="" />
+              </button>
+            </Dropdown>
           </PageHeader>
         </div>
       </div>

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -130,8 +130,8 @@ function Player() {
   const onTabChanged = useCallback(handleTabChanged, []);
   const onDeltasPeriodSelected = useCallback(handleDeltasPeriodSelected, [setSelectedDeltasPeriod]);
   const onSkillsPeriodSelected = useCallback(handleDeltasSkillSelected, [setSelectedDeltasSkill]);
-  const onUpdatedButtonClicked = useCallback(trackPlayer, [player]);
   const onOptionSelected = useCallback(handleOptionSelected, [player]);
+  const onUpdateButtonClicked = useCallback(trackPlayer, [player]);
 
   // Fetch all player info on mount
   useEffect(fetchAll, [dispatch, id]);
@@ -150,7 +150,7 @@ function Player() {
       <div className="player__header row">
         <div className="col">
           <PageHeader title={player.username} icon={getPlayerTypeIcon(player.type)}>
-            <Button text="Update" onClick={onUpdatedButtonClicked} loading={isTracking} />
+            <Button text="Update" onClick={onUpdateButtonClicked} loading={isTracking} />
             <Dropdown options={MENU_OPTIONS} onSelect={onOptionSelected}>
               <button className="header__options-btn" type="button">
                 <img src="/img/icons/options.svg" alt="" />

--- a/app/src/redux/middlewares/notifications.js
+++ b/app/src/redux/middlewares/notifications.js
@@ -1,5 +1,11 @@
 import { showNotification } from '../modules/notifications/actions/toggle';
-import { TRACK_PLAYER_SUCCESS, TRACK_PLAYER_FAILURE } from '../modules/players/reducer';
+import {
+  TRACK_PLAYER_SUCCESS,
+  TRACK_PLAYER_FAILURE,
+  ASSERT_TYPE_SUCCESS,
+  ASSERT_TYPE_FAILURE,
+  ASSERT_TYPE_REQUEST
+} from '../modules/players/reducer';
 import {
   CREATE_GROUP_FAILURE,
   CREATE_GROUP_SUCCESS,
@@ -33,6 +39,37 @@ const notificationsMiddleware = store => next => action => {
     }
 
     case TRACK_PLAYER_FAILURE: {
+      const notification = {
+        text: action.error,
+        type: 'error'
+      };
+
+      store.dispatch(showNotification({ ...notification }));
+      break;
+    }
+
+    case ASSERT_TYPE_REQUEST: {
+      const notification = {
+        text: `Reasigning player type..`,
+        type: 'warn',
+        duration: 10000
+      };
+
+      store.dispatch(showNotification({ ...notification }));
+      break;
+    }
+
+    case ASSERT_TYPE_SUCCESS: {
+      const notification = {
+        text: `Player type successfully reasigned to ${action.playerType}.`,
+        type: 'success'
+      };
+
+      store.dispatch(showNotification({ ...notification }));
+      break;
+    }
+
+    case ASSERT_TYPE_FAILURE: {
       const notification = {
         text: action.error,
         type: 'error'

--- a/app/src/redux/modules/players/actions/assertType.js
+++ b/app/src/redux/modules/players/actions/assertType.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import Analytics from 'react-ga';
+import { BASE_API_URL } from '../../../../config';
+import { ASSERT_TYPE_REQUEST, ASSERT_TYPE_SUCCESS, ASSERT_TYPE_FAILURE } from '../reducer';
+
+function assertTypeRequest() {
+  return {
+    type: ASSERT_TYPE_REQUEST
+  };
+}
+
+function assertTypeSuccess(data, username, playerId) {
+  Analytics.event({
+    category: 'Player',
+    action: 'Asserted player type',
+    value: username
+  });
+
+  return {
+    type: ASSERT_TYPE_SUCCESS,
+    playerId,
+    playerType: data.type
+  };
+}
+
+function assertTypeFailure(error) {
+  return {
+    type: ASSERT_TYPE_FAILURE,
+    error: error.response.data.message
+  };
+}
+
+export default function assertType(username, playerId) {
+  return dispatch => {
+    dispatch(assertTypeRequest(username));
+
+    const url = `${BASE_API_URL}/players/assert-type/`;
+    const body = { username };
+
+    return axios
+      .post(url, body)
+      .then(result => dispatch(assertTypeSuccess(result.data, username, playerId)))
+      .catch(error => dispatch(assertTypeFailure(error, username)));
+  };
+}

--- a/app/src/redux/modules/players/reducer.js
+++ b/app/src/redux/modules/players/reducer.js
@@ -4,6 +4,10 @@ export const TRACK_PLAYER_REQUEST = 'wise-old-man/players/TRACK_REQUEST';
 export const TRACK_PLAYER_SUCCESS = 'wise-old-man/players/TRACK_SUCCESS';
 export const TRACK_PLAYER_FAILURE = 'wise-old-man/players/TRACK_FAILURE';
 
+export const ASSERT_TYPE_REQUEST = 'wise-old-man/players/ASSERT_TYPE_REQUEST';
+export const ASSERT_TYPE_SUCCESS = 'wise-old-man/players/ASSERT_TYPE_SUCCESS';
+export const ASSERT_TYPE_FAILURE = 'wise-old-man/players/ASSERT_TYPE_FAILURE';
+
 export const FETCH_PLAYER_REQUEST = 'wise-old-man/players/FETCH_REQUEST';
 export const FETCH_PLAYER_SUCCESS = 'wise-old-man/players/FETCH_SUCCESS';
 export const FETCH_PLAYER_FAILURE = 'wise-old-man/players/FETCH_FAILURE';
@@ -15,27 +19,50 @@ export const SEARCH_PLAYERS_FAILURE = 'wise-old-man/players/SEARCH_FAILURE';
 const initialState = {
   isFetching: false,
   isSearching: false,
+  isTracking: false,
+  isAssertingType: false,
   players: {},
   searchResults: {},
-  updating: [],
+  updating: []
 };
 
 export default function playersReducer(state = initialState, action) {
   switch (action.type) {
     case TRACK_PLAYER_REQUEST:
-      return { ...state, updating: [...state.updating, action.username] };
+      return { ...state, isTracking: true, updating: [...state.updating, action.username] };
 
     case TRACK_PLAYER_SUCCESS:
       return {
         ...state,
+        isTracking: false,
         updating: [...state.updating.filter(username => username !== action.username)],
-        players: { ...state.players, [action.data.id]: { ...action.data } },
+        players: { ...state.players, [action.data.id]: { ...action.data } }
       };
 
     case TRACK_PLAYER_FAILURE:
       return {
         ...state,
-        updating: [...state.updating.filter(username => username !== action.username)],
+        isTracking: false,
+        updating: [...state.updating.filter(username => username !== action.username)]
+      };
+
+    case ASSERT_TYPE_REQUEST:
+      return { ...state, isAssertingType: true };
+
+    case ASSERT_TYPE_SUCCESS:
+      return {
+        ...state,
+        isAssertingType: false,
+        players: {
+          ...state.players,
+          [action.playerId]: { ...state.players[action.playerId], type: action.playerType }
+        }
+      };
+
+    case ASSERT_TYPE_FAILURE:
+      return {
+        ...state,
+        isAssertingType: false
       };
 
     case FETCH_PLAYER_REQUEST:
@@ -45,7 +72,7 @@ export default function playersReducer(state = initialState, action) {
       return {
         ...state,
         isFetching: false,
-        players: { ...state.players, [action.player.id]: action.player },
+        players: { ...state.players, [action.player.id]: action.player }
       };
 
     case FETCH_PLAYER_FAILURE:
@@ -59,7 +86,7 @@ export default function playersReducer(state = initialState, action) {
         ...state,
         isSearching: false,
         searchResults: { ...toMap(action.players, 'id') },
-        players: { ...state.players, ...toMap(action.players, 'id') },
+        players: { ...state.players, ...toMap(action.players, 'id') }
       };
 
     case SEARCH_PLAYERS_FAILURE:

--- a/docs/src/configs/docs/players/endpoints.js
+++ b/docs/src/configs/docs/players/endpoints.js
@@ -6,15 +6,15 @@ export default [
     comments: [
       {
         type: 'info',
-        content: 'This will only return the top 20 player results.',
-      },
+        content: 'This will only return the top 20 player results.'
+      }
     ],
     query: [
       {
         field: 'username',
         type: 'string',
-        description: 'A partial username match.',
-      },
+        description: 'A partial username match.'
+      }
     ],
     successResponses: [
       {
@@ -26,7 +26,7 @@ export default [
             type: 'ironman',
             lastImportedAt: null,
             registeredAt: '2020-04-04T21:48:19.197Z',
-            updatedAt: '2020-04-04T21:48:29.235Z',
+            updatedAt: '2020-04-04T21:48:29.235Z'
           },
           {
             id: 45,
@@ -34,19 +34,19 @@ export default [
             type: 'regular',
             lastImportedAt: null,
             registeredAt: '2020-04-04T21:48:31.367Z',
-            updatedAt: '2020-04-04T21:48:39.636Z',
-          },
-        ],
-      },
+            updatedAt: '2020-04-04T21:48:39.636Z'
+          }
+        ]
+      }
     ],
     errorResponses: [
       {
         description: 'If no username is given.',
         body: {
-          message: 'Invalid username.',
-        },
-      },
-    ],
+          message: 'Invalid username.'
+        }
+      }
+    ]
   },
   {
     title: 'View player',
@@ -55,20 +55,20 @@ export default [
     comments: [
       {
         type: 'warning',
-        content: 'If both "username" and "id" are given in the query params, "id" will be ignored.',
-      },
+        content: 'If both "username" and "id" are given in the query params, "id" will be ignored.'
+      }
     ],
     query: [
       {
         field: 'id',
         type: 'integer',
-        description: "The player's id.",
+        description: "The player's id."
       },
       {
         field: 'username',
         type: 'string',
-        description: "The player's username.",
-      },
+        description: "The player's username."
+      }
     ],
     successResponses: [
       {
@@ -85,36 +85,36 @@ export default [
             importedAt: null,
             overall: {
               rank: 30400,
-              experience: 269828205,
+              experience: 269828205
             },
             attack: {
               rank: 12158,
-              experience: 27216011,
-            },
-          },
-        },
-      },
+              experience: 27216011
+            }
+          }
+        }
+      }
     ],
     errorResponses: [
       {
         description: 'If no id or username are given.',
         body: {
-          message: 'Invalid player id.',
-        },
+          message: 'Invalid player id.'
+        }
       },
       {
         description: 'If an id is given but does not exist.',
         body: {
-          message: 'Player of id 5767 is not being tracked yet.',
-        },
+          message: 'Player of id 5767 is not being tracked yet.'
+        }
       },
       {
         description: 'If an username is given but does not exist.',
         body: {
-          message: 'someUsername is not being tracked yet.',
-        },
-      },
-    ],
+          message: 'someUsername is not being tracked yet.'
+        }
+      }
+    ]
   },
   {
     title: 'Track player',
@@ -125,17 +125,17 @@ export default [
         type: 'info',
         content:
           "If the player's type is unknown, this will trigger a \
-          job to determine the player's type.",
+          job to determine the player's type."
       },
       {
         type: 'info',
         content:
           "If the player hasn't been imported from CML within the \
-          last 24 hours, this will trigger a job to import the player's history from CML.",
-      },
+          last 24 hours, this will trigger a job to import the player's history from CML."
+      }
     ],
     body: {
-      username: 'psikoi',
+      username: 'psikoi'
     },
     successResponses: [
       {
@@ -152,37 +152,73 @@ export default [
             importedAt: null,
             overall: {
               rank: 30420,
-              experience: 269900478,
+              experience: 269900478
             },
             attack: {
               rank: 12159,
-              experience: 27216011,
-            },
-          },
-        },
-      },
+              experience: 27216011
+            }
+          }
+        }
+      }
     ],
     errorResponses: [
       {
         description: 'If no username is given.',
         body: {
-          message: 'Invalid username.',
-        },
+          message: 'Invalid username.'
+        }
       },
       {
         description: 'If the player was updated too recently (< 60 seconds)',
         body: {
-          message: 'Failed to update: psikoi was updated 43 seconds ago.',
-        },
+          message: 'Failed to update: psikoi was updated 43 seconds ago.'
+        }
       },
       {
         description:
           'If the username does not exist (in Runescape) OR failed to fetch from the hiscores.',
         body: {
-          message: 'Failed to load hiscores: Invalid username',
-        },
-      },
+          message: 'Failed to load hiscores: Invalid username'
+        }
+      }
+    ]
+  },
+  {
+    title: 'Assert player type (reasign)',
+    url: '/players/assert-type',
+    method: 'POST',
+    body: {
+      username: 'psikoi'
+    },
+    successResponses: [
+      {
+        description: '',
+        body: {
+          type: 'regular'
+        }
+      }
     ],
+    errorResponses: [
+      {
+        description: 'If no username is given.',
+        body: {
+          message: 'Invalid username.'
+        }
+      },
+      {
+        description: 'If the username is not tracked.',
+        body: {
+          message: 'Invalid player: Psikoi is not being tracked yet.'
+        }
+      },
+      {
+        description: 'If the API fails to fetch initial (regular) hiscores data.',
+        body: {
+          message: "Couldn't find player Psikoi in the hiscores."
+        }
+      }
+    ]
   },
   {
     title: 'Import player',
@@ -193,39 +229,39 @@ export default [
         type: 'info',
         content:
           "If the player's has been imported before, this will only import the CML history \
-          since the last import, otherwise it will import all the existing history.",
-      },
+          since the last import, otherwise it will import all the existing history."
+      }
     ],
     body: {
-      username: 'psikoi',
+      username: 'psikoi'
     },
     successResponses: [
       {
         description: '',
         body: {
-          message: '157 snapshots imported from CML.',
-        },
-      },
+          message: '157 snapshots imported from CML.'
+        }
+      }
     ],
     errorResponses: [
       {
         description: 'If no username is given.',
         body: {
-          message: 'Invalid username.',
-        },
+          message: 'Invalid username.'
+        }
       },
       {
         description: 'If the player was imported too recently (< 24 hours)',
         body: {
-          message: 'Imported too soon, please wait another 1354 minutes.',
-        },
+          message: 'Imported too soon, please wait another 1354 minutes.'
+        }
       },
       {
         description: 'If the username does not exist (in CML) OR failed to fetch from CML.',
         body: {
-          message: 'Failed to load history from CML.',
-        },
-      },
-    ],
-  },
+          message: 'Failed to load history from CML.'
+        }
+      }
+    ]
+  }
 ];

--- a/server/src/api/jobs/instances/ConfirmPlayerType.js
+++ b/server/src/api/jobs/instances/ConfirmPlayerType.js
@@ -4,6 +4,6 @@ module.exports = {
   key: 'ConfirmPlayerType',
   async handle({ data }) {
     const { player } = data;
-    await playerService.confirmType(player.username);
+    await playerService.assertType(player.username);
   }
 };

--- a/server/src/api/modules/players/player.controller.js
+++ b/server/src/api/modules/players/player.controller.js
@@ -41,6 +41,17 @@ async function track(req, res, next) {
   }
 }
 
+async function assertType(req, res, next) {
+  try {
+    const { username } = req.body;
+
+    const type = await service.assertType(username, true);
+    res.status(200).json({ type });
+  } catch (e) {
+    next(e);
+  }
+}
+
 async function importPlayer(req, res, next) {
   try {
     const { username } = req.body;
@@ -57,4 +68,5 @@ async function importPlayer(req, res, next) {
 exports.get = get;
 exports.search = search;
 exports.track = track;
+exports.assertType = assertType;
 exports.importPlayer = importPlayer;

--- a/server/src/api/modules/players/player.route.js
+++ b/server/src/api/modules/players/player.route.js
@@ -7,5 +7,6 @@ api.get('/', controller.get);
 api.get('/search', controller.search);
 api.post('/track', controller.track);
 api.post('/import', controller.importPlayer);
+api.post('/assert-type', controller.assertType);
 
 module.exports = api;

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -273,6 +273,14 @@ async function getOverallExperience(username, hiscoresType) {
  * ironman exp is higher than the hardcore exp (meaning it progressed further as an ironman)
  */
 async function assertType(username, force = false) {
+  async function submitType(player, type) {
+    if (player.type === type) {
+      throw new BadRequestError(`Failed to reasign player type: ${username}'s is already ${type}.`);
+    }
+
+    await player.update({ type });
+  }
+
   if (!username) {
     throw new BadRequestError('Invalid username.');
   }
@@ -298,25 +306,25 @@ async function assertType(username, force = false) {
   const ironmanExp = await getOverallExperience(formattedUsername, 'IRONMAN');
 
   if (ironmanExp < regularExp) {
-    await player.update({ type: 'regular' });
+    await submitType(player, 'regular');
     return 'regular';
   }
 
   const hardcoreExp = await getOverallExperience(formattedUsername, 'HARDCORE_IRONMAN');
 
   if (hardcoreExp >= ironmanExp) {
-    await player.update({ type: 'hardcore' });
+    await submitType(player, 'hardcore');
     return 'hardcore';
   }
 
   const ultimateExp = await getOverallExperience(formattedUsername, 'ULTIMATE_IRONMAN');
 
   if (ultimateExp >= ironmanExp) {
-    await player.update({ type: 'ultimate' });
+    await submitType(player, 'ultimate');
     return 'ultimate';
   }
 
-  await player.update({ type: 'ironman' });
+  await submitType(player, 'ironman');
   return 'ironman';
 }
 

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -225,59 +225,99 @@ async function importCMLSince(id, username, time) {
 }
 
 /**
- * Check the hiscores to check if a player
- * with a given username is of a specific player type.
+ * Gets a player's overall experience in a specific
+ * player type hiscores endpoint.
+ *
+ * Note: This is an auxilary function for the assertType function
+ * and should not be used for any other situation.
  */
-async function isType(username, type) {
+async function getOverallExperience(username, hiscoresType) {
   try {
-    await getHiscoresData(username, type);
-    return true;
+    const data = await getHiscoresData(username, hiscoresType);
+
+    if (!data || data.length === 0) {
+      throw new ServerError('Failed to fetch hiscores data.');
+    }
+
+    const rows = data.split('\n');
+
+    if (!rows || rows.length === 0) {
+      throw new ServerError('Failed to fetch hiscores data.');
+    }
+
+    const values = rows[0].split(',');
+
+    if (values.length < 3) {
+      throw new ServerError('Failed to fetch hiscores data.');
+    }
+
+    return parseInt(values[2], 10);
   } catch (e) {
-    // If the hiscores are down, abort mission,
-    // otherwise if it's a BadRequestError,
-    // then it's possible the player is not of "type"
     if (e instanceof ServerError) {
       throw e;
     }
+    return -1;
   }
-
-  return false;
 }
 
 /**
- * If a player type is unknown, check different
- * hiscores endpoints to try and determine it.
+ * Query the multiple hiscore endpoints to try and determine
+ * the player's account type.
+ *
+ * If force is true, this will reassign the type, even if the current
+ * value is not unknown.
+ *
+ * Note: If an hardcore acc dies at 1m overall exp, it stays that way in the
+ * hardcore hiscores, even if the regular ironman hiscores continue to progress.
+ * So to check if the player is no longer hardcore, we have to check if the
+ * ironman exp is higher than the hardcore exp (meaning it progressed further as an ironman)
  */
-async function confirmType(username) {
+async function assertType(username, force = false) {
   if (!username) {
     throw new BadRequestError('Invalid username.');
   }
 
-  const [player] = await findOrCreate(username);
+  const formattedUsername = formatUsername(username);
 
-  if (!player || !player.type) {
-    throw new ServerError('Invalid player.');
+  const player = await find(formattedUsername);
+
+  if (!player) {
+    throw new BadRequestError(`Invalid player: ${username} is not being tracked yet.`);
   }
 
-  if (player.type !== 'unknown') {
+  if (!force && player.type !== 'unknown') {
     return player.type;
   }
 
-  let type = 'regular';
+  const regularExp = await getOverallExperience(formattedUsername, 'NORMAL');
 
-  if (await isType(player.username, 'IRONMAN')) {
-    if (await isType(player.username, 'ULTIMATE_IRONMAN')) {
-      type = 'ultimate';
-    } else if (await isType(player.username, 'HARDCORE_IRONMAN')) {
-      type = 'hardcore';
-    } else {
-      type = 'ironman';
-    }
+  if (regularExp === -1) {
+    throw new BadRequestError(`Couldn't find player ${username} in the hiscores.`);
   }
 
-  await player.update({ type });
+  const ironmanExp = await getOverallExperience(formattedUsername, 'IRONMAN');
 
-  return type;
+  if (ironmanExp < regularExp) {
+    await player.update({ type: 'regular' });
+    return 'regular';
+  }
+
+  const hardcoreExp = await getOverallExperience(formattedUsername, 'HARDCORE_IRONMAN');
+
+  if (hardcoreExp >= ironmanExp) {
+    await player.update({ type: 'hardcore' });
+    return 'hardcore';
+  }
+
+  const ultimateExp = await getOverallExperience(formattedUsername, 'ULTIMATE_IRONMAN');
+
+  if (ultimateExp >= ironmanExp) {
+    await player.update({ type: 'ultimate' });
+    return 'ultimate';
+  }
+
+  await player.update({ type: 'ironman' });
+  return 'ironman';
 }
 
 async function findOrCreate(username) {
@@ -362,7 +402,7 @@ exports.getData = getData;
 exports.search = search;
 exports.update = update;
 exports.importCML = importCML;
-exports.confirmType = confirmType;
+exports.assertType = assertType;
 exports.find = find;
 exports.findById = findById;
 exports.findOrCreate = findOrCreate;


### PR DESCRIPTION
So apparently when an hardcore dies, their hiscores remain alive, they just won't progress anymore.

So I had to restructure the player type asserting to reflect player status changes (hardcore deaths, and de-irons)

Also added /players/assert-type endpoint and a menu option on the player page to call it.