### PR TITLE
line-graph: use point hover mode

### DIFF
--- a/app/src/components/LineChart/LineChart.jsx
+++ b/app/src/components/LineChart/LineChart.jsx
@@ -23,6 +23,9 @@ function getConfig(datasets, invertYAxis) {
           padding: 30
         }
       },
+      hover: {
+        mode: 'point'
+      },
       tooltips: {
         callbacks: {
           title: data => formatDate(data[0].xLabel, 'DD MMM, HH:mm'),


### PR DESCRIPTION
This previously used index which made the all points with the same
index of all datasets look selected when you hover on any one of them.