### PR TITLE
Fix forms loading state

### DIFF
--- a/app/src/pages/Competition/Competition.jsx
+++ b/app/src/pages/Competition/Competition.jsx
@@ -137,7 +137,9 @@ function Competition() {
       </div>
       <div className="competition__widgets row">
         <div className="col-md-4">
-          <span className="widget-label">Time Remaining</span>
+          <span className="widget-label">
+            {competition.status === 'upcoming' ? 'Starting in' : 'Time Remaining'}
+          </span>
           <CountdownWidget competition={competition} />
         </div>
         <div className="col-md-4 col-sm-6">

--- a/app/src/pages/CreateCompetition/CreateCompetition.jsx
+++ b/app/src/pages/CreateCompetition/CreateCompetition.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import moment from 'moment';
@@ -17,6 +17,7 @@ import VerificationPopup from './components/VerificationPopup';
 import { capitalize, getSkillIcon } from '../../utils';
 import { SKILLS } from '../../config';
 import createCompetitionAction from '../../redux/modules/competitions/actions/create';
+import { isCreating } from '../../redux/selectors/competitions';
 import './CreateCompetition.scss';
 
 function getMetricOptions() {
@@ -32,6 +33,8 @@ function getMetricOptions() {
 function CreateCompetition() {
   const router = useHistory();
   const dispatch = useDispatch();
+
+  const isSubmitting = useSelector(state => isCreating(state));
 
   const metricOptions = useMemo(getMetricOptions, [SKILLS]);
 
@@ -179,7 +182,7 @@ function CreateCompetition() {
         </div>
 
         <div className="form-row form-actions">
-          <Button text="Confirm" onClick={onSubmit} />
+          <Button text="Confirm" onClick={onSubmit} loading={isSubmitting} />
         </div>
       </div>
       {showingImportPopup && (

--- a/app/src/pages/CreateCompetition/components/ParticipantsSelector/ParticipantsSelector.scss
+++ b/app/src/pages/CreateCompetition/components/ParticipantsSelector/ParticipantsSelector.scss
@@ -30,7 +30,6 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      transition: 0.1s;
       cursor: pointer;
 
       &:hover {
@@ -40,7 +39,6 @@
       &:active,
       &:focus {
         opacity: 0.7;
-        transform: scale(0.7);
       }
 
       &__icon {

--- a/app/src/pages/CreateGroup/CreateGroup.jsx
+++ b/app/src/pages/CreateGroup/CreateGroup.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import PageTitle from '../../components/PageTitle';
@@ -10,11 +10,14 @@ import MembersSelector from './components/MembersSelector';
 import MembersModal from './components/MembersModal';
 import VerificationModal from './components/VerificationModal';
 import createGroupAction from '../../redux/modules/groups/actions/create';
+import { isCreating } from '../../redux/selectors/groups';
 import './CreateGroup.scss';
 
 function CreateGroup() {
   const router = useHistory();
   const dispatch = useDispatch();
+
+  const isSubmitting = useSelector(state => isCreating(state));
 
   const [name, setName] = useState('');
   const [members, setMembers] = useState([]);
@@ -62,10 +65,7 @@ function CreateGroup() {
   };
 
   const handleModalSubmit = usernames => {
-    usernames.forEach(u => {
-      handleAddMember(u);
-    });
-
+    setMembers([...usernames.map(u => ({ username: u, role: 'member' }))]);
     toggleImportModal(false);
   };
 
@@ -125,7 +125,7 @@ function CreateGroup() {
         </div>
 
         <div className="form-row form-actions">
-          <Button text="Confirm" onClick={onSubmit} />
+          <Button text="Confirm" onClick={onSubmit} loading={isSubmitting} />
         </div>
       </div>
       {showingImportModal && (

--- a/app/src/pages/EditCompetition/EditCompetition.jsx
+++ b/app/src/pages/EditCompetition/EditCompetition.jsx
@@ -15,7 +15,7 @@ import { capitalize, getSkillIcon } from '../../utils';
 import { SKILLS } from '../../config';
 import fetchDetailsAction from '../../redux/modules/competitions/actions/fetchDetails';
 import editAction from '../../redux/modules/competitions/actions/edit';
-import { getCompetition } from '../../redux/selectors/competitions';
+import { getCompetition, isEditing } from '../../redux/selectors/competitions';
 import './EditCompetition.scss';
 
 function getMetricOptions() {
@@ -49,6 +49,7 @@ function EditCompetition() {
   const [showingImportPopup, toggleImportPopup] = useState(false);
 
   const competition = useSelector(state => getCompetition(state, parseInt(id, 10)));
+  const isSubmitting = useSelector(state => isEditing(state));
 
   const metricIndex = useMemo(() => metricOptions.findIndex(o => o.value === metric), [
     metricOptions,
@@ -199,7 +200,7 @@ function EditCompetition() {
         </div>
 
         <div className="form-row form-actions">
-          <Button text="Confirm" onClick={onSubmit} />
+          <Button text="Confirm" onClick={onSubmit} loading={isSubmitting} />
         </div>
       </div>
       {showingImportPopup && (

--- a/app/src/pages/EditCompetition/components/ParticipantsSelector/ParticipantsSelector.scss
+++ b/app/src/pages/EditCompetition/components/ParticipantsSelector/ParticipantsSelector.scss
@@ -30,7 +30,6 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      transition: 0.1s;
       cursor: pointer;
 
       &:hover {
@@ -40,7 +39,6 @@
       &:active,
       &:focus {
         opacity: 0.7;
-        transform: scale(0.7);
       }
 
       &__icon {

--- a/app/src/pages/EditGroup/EditGroup.jsx
+++ b/app/src/pages/EditGroup/EditGroup.jsx
@@ -10,7 +10,8 @@ import MembersSelector from './components/MembersSelector';
 import MembersModal from './components/MembersModal';
 import editGroupAction from '../../redux/modules/groups/actions/edit';
 import fetchDetailsAction from '../../redux/modules/groups/actions/fetchDetails';
-import { getGroup } from '../../redux/selectors/groups';
+import fetchMembersAction from '../../redux/modules/groups/actions/fetchMembers';
+import { getGroup, isEditing } from '../../redux/selectors/groups';
 import './EditGroup.scss';
 
 function EditGroup() {
@@ -24,9 +25,11 @@ function EditGroup() {
   const [verificationCode, setVerificationCode] = useState('');
 
   const group = useSelector(state => getGroup(state, parseInt(id, 10)));
+  const isSubmitting = useSelector(state => isEditing(state));
 
   const fetchDetails = () => {
     dispatch(fetchDetailsAction(id));
+    dispatch(fetchMembersAction(id));
   };
 
   const populate = () => {
@@ -80,10 +83,7 @@ function EditGroup() {
   };
 
   const handleModalSubmit = usernames => {
-    usernames.forEach(u => {
-      handleAddMember(u);
-    });
-
+    setMembers([...usernames.map(u => ({ username: u, role: 'member' }))]);
     toggleImportModal(false);
   };
 
@@ -151,7 +151,7 @@ function EditGroup() {
         </div>
 
         <div className="form-row form-actions">
-          <Button text="Confirm" onClick={onSubmit} />
+          <Button text="Confirm" onClick={onSubmit} loading={isSubmitting} />
         </div>
       </div>
       {showingImportModal && (

--- a/app/src/redux/selectors/competitions.js
+++ b/app/src/redux/selectors/competitions.js
@@ -10,6 +10,8 @@ const groupCompetitionsSelector = state => state.competitions.groupCompetitions;
 
 export const isFetchingAll = createSelector(rootSelector, root => root.isFetchingAll);
 export const isFetchingDetails = createSelector(rootSelector, root => root.isFetchingDetails);
+export const isCreating = createSelector(rootSelector, root => root.isCreating);
+export const isEditing = createSelector(rootSelector, root => root.isEditing);
 
 export const getCompetitionsMap = createSelector(competitionsSelector, map => {
   return _.mapValues(map, comp => formatCompetition(comp));

--- a/app/src/redux/selectors/groups.js
+++ b/app/src/redux/selectors/groups.js
@@ -9,6 +9,8 @@ export const isFetchingAll = createSelector(rootSelector, root => root.isFetchin
 export const isFetchingDetails = createSelector(rootSelector, root => root.isFetchingDetails);
 export const isFetchingMembers = createSelector(rootSelector, root => root.isFetchingMembers);
 export const isFetchingMonthlyTop = createSelector(rootSelector, root => root.isFetchingMonthlyTop);
+export const isCreating = createSelector(rootSelector, root => root.isCreating);
+export const isEditing = createSelector(rootSelector, root => root.isEditing);
 
 export const getGroupsMap = createSelector(groupsSelector, map => {
   return _.mapValues(map, group => formatGroup(group));


### PR DESCRIPTION
Fixes #58 
Fixes #67 

- Adds loading states to group create/edit pages
- Adds loading states to competition create/edit pages
- Fixes lag when importing large member lists in group create/edit pages
- Fixes lag when importing large participant lists in competition create/edit pages
- Fixes the competition timer label "Starting in" for upcoming competitions