### PR TITLE
Fix records & top layout

### DIFF
--- a/app/src/pages/Records/Records.jsx
+++ b/app/src/pages/Records/Records.jsx
@@ -19,7 +19,11 @@ const DEFAULT_TYPE_OPTIONS = { label: 'Any player', value: null };
 const TABLE_CONFIG = {
   uniqueKey: row => row.username,
   columns: [
-    { key: 'rank', width: '30' },
+    {
+      key: 'rank',
+      width: '10',
+      transform: rank => <span className="record-rank">{rank}</span>
+    },
     {
       key: 'username',
       className: () => '-primary',
@@ -28,7 +32,11 @@ const TABLE_CONFIG = {
     {
       key: 'updatedAt',
       className: () => '-break-small',
-      transform: value => formatDate(value, 'DD-MM-YYYY')
+      transform: value => (
+        <abbr title={formatDate(value, 'Do MMM YYYY HH:mm')}>
+          <span className="record-date">{formatDate(value, "DD MMM 'YY")}</span>
+        </abbr>
+      )
     },
     {
       key: 'value',

--- a/app/src/pages/Records/Records.scss
+++ b/app/src/pages/Records/Records.scss
@@ -4,6 +4,23 @@
 .records__container {
   @extend %page;
 
+  abbr {
+    text-decoration: none;
+  }
+
+  td {
+    padding: 5px;
+  }
+
+  .record-rank {
+    font-size: 0.9em;
+  }
+
+  .col,
+  [class*='col-'] {
+    padding: 6px;
+  }
+
   .table-list-placeholder {
     margin-top: 15px;
   }

--- a/app/src/pages/Top/Top.jsx
+++ b/app/src/pages/Top/Top.jsx
@@ -19,7 +19,11 @@ const DEFAULT_TYPE_OPTIONS = { label: 'All players', value: null };
 const TABLE_CONFIG = {
   uniqueKey: row => row.username,
   columns: [
-    { key: 'rank', width: 30 },
+    {
+      key: 'rank',
+      width: '30',
+      transform: rank => <span className="top-rank">{rank}</span>
+    },
     {
       key: 'username',
       className: () => '-primary',
@@ -27,6 +31,7 @@ const TABLE_CONFIG = {
     },
     {
       key: 'gained',
+      width: 90,
       transform: val => <NumberLabel value={val} isColored />
     }
   ]

--- a/app/src/pages/Top/Top.scss
+++ b/app/src/pages/Top/Top.scss
@@ -4,6 +4,19 @@
 .top__container {
   @extend %page;
 
+  td {
+    padding: 5px;
+  }
+
+  .top-rank {
+    font-size: 0.9em;
+  }
+
+  .col,
+  [class*='col-'] {
+    padding: 6px;
+  }
+
   .table-list-placeholder {
     margin-top: 15px;
   }


### PR DESCRIPTION
Reduce column and font sizes to prevent line breaks and other visual issues.

- Changes the way dates are displayed in the record page. Ex `06 May '20`
- Adds a hover for full date and time on record row