### PR TITLE
Improve delta & competition gains fetching efficiency

### DIFF
--- a/server/src/api/modules/competitions/competition.service.js
+++ b/server/src/api/modules/competitions/competition.service.js
@@ -178,8 +178,8 @@ async function view(id) {
     where: { competitionId: id },
     include: [
       { model: Player },
-      { model: Snapshot, as: 'startSnapshot' },
-      { model: Snapshot, as: 'endSnapshot' }
+      { model: Snapshot, as: 'startSnapshot', attributes: [metricKey] },
+      { model: Snapshot, as: 'endSnapshot', attributes: [metricKey] }
     ]
   });
 

--- a/server/src/api/modules/deltas/delta.service.js
+++ b/server/src/api/modules/deltas/delta.service.js
@@ -185,8 +185,8 @@ async function getPeriodLeaderboard(metric, period, playerType) {
     limit: 20,
     include: [
       { model: Player, where: playerType && { type: playerType } },
-      { model: Snapshot, as: 'startSnapshot' },
-      { model: Snapshot, as: 'endSnapshot' }
+      { model: Snapshot, as: 'startSnapshot', attributes: [metricKey] },
+      { model: Snapshot, as: 'endSnapshot', attributes: [metricKey] }
     ]
   });
 
@@ -223,8 +223,8 @@ async function getMonthlyTop(playerIds) {
     limit: 1,
     include: [
       { model: Player, where: { id: playerIds } },
-      { model: Snapshot, as: 'startSnapshot' },
-      { model: Snapshot, as: 'endSnapshot' }
+      { model: Snapshot, as: 'startSnapshot', attributes: [metricKey] },
+      { model: Snapshot, as: 'endSnapshot', attributes: [metricKey] }
     ]
   });
 


### PR DESCRIPTION
By only selecting the necessary snapshot attributes, this should improve loading times for:

- Fetching delta leaderboards
- Fetching competition participant gains
- Fetching a group's monthly top player