### PR TITLE
Fix record create & increase connection pool size

### DIFF
--- a/server/src/api/modules/records/record.service.js
+++ b/server/src/api/modules/records/record.service.js
@@ -20,16 +20,43 @@ async function syncRecords(playerId, period) {
     throw new BadRequestError(`Invalid player.`);
   }
 
-  const delta = await deltaService.getDelta(playerId, period);
+  const allRecordDefs = SKILLS.map(metric => ({ period, metric }));
+  const periodDelta = await deltaService.getDelta(playerId, period);
+  let playerRecords = await Record.findAll({ where: { playerId, period } });
+
+  // If has missing records, create them
+  if (playerRecords.length !== allRecordDefs.length) {
+    // Create a map of all metrics (ex: {"woodcutting": false, "prayer": false})
+    const checkMap = _.mapValues(_.keyBy(allRecordDefs, 'metric'), () => false);
+
+    // Mark any found playerRecords as existant (true)
+    playerRecords.forEach(r => {
+      checkMap[r.metric] = true;
+    });
+
+    // Gather the record definitions for any missing records
+    const missingRecordDefs = Object.keys(checkMap)
+      .map(k => ({ key: k, value: checkMap[k] }))
+      .filter(m => !m.value)
+      .map(m => ({ playerId, period, metric: m.key, value: 0 }));
+
+    // Add all missing records
+    const newRecords = await Record.bulkCreate(missingRecordDefs, { ignoreDuplicates: true });
+
+    // Add newly created records to the playerRecords array, to be processed later on
+    if (newRecords && newRecords.length > 0) {
+      playerRecords = [...playerRecords, ...newRecords];
+    }
+  }
 
   await Promise.all(
-    SKILLS.map(async metric => {
-      const [record] = await Record.findOrCreate({ where: { playerId, period, metric } });
-      const newValue = delta.data[metric].experience.delta;
+    playerRecords.map(async record => {
+      const { value, metric } = record;
+      const newValue = periodDelta.data[metric].experience.delta;
 
       // If the current delta is higher than the previous record,
       // update the previous record's value
-      if (record.value < newValue) {
+      if (value < newValue) {
         await record.update({ value: newValue });
       }
 

--- a/server/src/database/config.js
+++ b/server/src/database/config.js
@@ -8,6 +8,6 @@ module.exports = {
   dialect: process.env.DB_DIALECT,
   storage: process.env.DB_STORAGE,
   logging: false,
-  pool: { max: 5, min: 0, acquire: 20000, idle: 10000 },
+  pool: { max: 40, min: 2, acquire: 20000, idle: 5000 },
   retry: { max: 10 }
 };


### PR DESCRIPTION
Everytime a player was updated, it was making 96 database operations to fetch or create records, this of course is ridiculous and should have never happened. This would sometimes cause the connection pool to run out of connections, and was probably the cause for duplicated records.

Also increase connection pool size.

