### PR TITLE
Fix Runecrafting Icon on Achievements page

### DIFF
--- a/app/src/config/skills.js
+++ b/app/src/config/skills.js
@@ -12,6 +12,7 @@ export const SKILLS = [
   'fletching',
   'fishing',
   'firemaking',
+  'runecrafting',
   'crafting',
   'smithing',
   'mining',
@@ -20,7 +21,6 @@ export const SKILLS = [
   'thieving',
   'slayer',
   'farming',
-  'runecrafting',
   'hunter',
   'construction',
 ];


### PR DESCRIPTION
Moved runecrafting above crafting in skills list as "runecrafting" includes "crafting"