### PR TITLE
Fix ironmen rank

### DIFF
--- a/server/src/api/constants/services.json
+++ b/server/src/api/constants/services.json
@@ -1,11 +1,9 @@
 {
   "OSRS_HISCORES": {
-    "NORMAL": "https://services.runescape.com/m=hiscore_oldschool/index_lite.ws",
-    "IRONMAN": "https://services.runescape.com/m=hiscore_oldschool_ironman/index_lite.ws",
-    "HARDCORE_IRONMAN": "https://services.runescape.com/m=hiscore_oldschool_hardcore_ironman/index_lite.ws",
-    "ULTIMATE_IRONMAN": "https://services.runescape.com/m=hiscore_oldschool_ultimate/index_lite.ws",
-    "DEADMAN": "https://services.runescape.com/m=hiscore_oldschool_deadman/index_lite.ws",
-    "LEAGUE": "https://services.runescape.com/m=hiscore_oldschool_seasonal/index_lite.ws"
+    "regular": "https://services.runescape.com/m=hiscore_oldschool/index_lite.ws",
+    "ironman": "https://services.runescape.com/m=hiscore_oldschool_ironman/index_lite.ws",
+    "hardcore": "https://services.runescape.com/m=hiscore_oldschool_hardcore_ironman/index_lite.ws",
+    "ultimate": "https://services.runescape.com/m=hiscore_oldschool_ultimate/index_lite.ws"
   },
   "CML": {
     "HISTORY": "https://crystalmathlabs.com/tracker/api.php?type=datapoints"

--- a/server/src/api/jobs/instances/ConfirmPlayerType.js
+++ b/server/src/api/jobs/instances/ConfirmPlayerType.js
@@ -1,9 +1,0 @@
-const playerService = require('../../modules/players/player.service');
-
-module.exports = {
-  key: 'ConfirmPlayerType',
-  async handle({ data }) {
-    const { player } = data;
-    await playerService.assertType(player.username);
-  }
-};

--- a/server/src/api/jobs/instances/index.js
+++ b/server/src/api/jobs/instances/index.js
@@ -1,4 +1,3 @@
-const ConfirmPlayerType = require('./ConfirmPlayerType');
 const ImportPlayer = require('./ImportPlayer');
 const UpdatePlayer = require('./UpdatePlayer');
 const SyncPlayerDeltas = require('./SyncPlayerDeltas');
@@ -11,7 +10,6 @@ const RemoveFromGroupCompetitions = require('./RemoveFromGroupCompetitions');
 module.exports = {
   ImportPlayer,
   UpdatePlayer,
-  ConfirmPlayerType,
   SyncPlayerDeltas,
   SyncPlayerRecords,
   SyncPlayerParticipations,

--- a/server/src/api/modules/players/player.controller.js
+++ b/server/src/api/modules/players/player.controller.js
@@ -31,7 +31,6 @@ async function track(req, res, next) {
     const player = await service.update(username);
 
     // Run secondary jobs
-    jobs.add('ConfirmPlayerType', { player });
     jobs.add('ImportPlayer', { player });
 
     // Send the http response back

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -158,8 +158,14 @@ async function update(username) {
   }
 
   try {
+    // If the player is new or has an unknown player type,
+    // determine it before tracking
+    if (player.type === 'unknown') {
+      player.type = await assertType(player.username);
+    }
+
     // Load data from OSRS hiscores
-    const hiscoresCSV = await getHiscoresData(player.username);
+    const hiscoresCSV = await getHiscoresData(player.username, player.type);
 
     // Convert the csv data to a Snapshot instance (saved in the DB)
     const currentSnapshot = await snapshotService.fromRS(player.id, hiscoresCSV);
@@ -248,9 +254,9 @@ async function importCMLSince(id, username, time) {
  * Note: This is an auxilary function for the assertType function
  * and should not be used for any other situation.
  */
-async function getOverallExperience(username, hiscoresType) {
+async function getOverallExperience(username, type) {
   try {
-    const data = await getHiscoresData(username, hiscoresType);
+    const data = await getHiscoresData(username, type);
 
     if (!data || data.length === 0) {
       throw new ServerError('Failed to fetch hiscores data.');
@@ -314,27 +320,27 @@ async function assertType(username, force = false) {
     return player.type;
   }
 
-  const regularExp = await getOverallExperience(formattedUsername, 'NORMAL');
+  const regularExp = await getOverallExperience(formattedUsername, 'regular');
 
   if (regularExp === -1) {
     throw new BadRequestError(`Couldn't find player ${username} in the hiscores.`);
   }
 
-  const ironmanExp = await getOverallExperience(formattedUsername, 'IRONMAN');
+  const ironmanExp = await getOverallExperience(formattedUsername, 'ironman');
 
   if (ironmanExp < regularExp) {
     await submitType(player, 'regular');
     return 'regular';
   }
 
-  const hardcoreExp = await getOverallExperience(formattedUsername, 'HARDCORE_IRONMAN');
+  const hardcoreExp = await getOverallExperience(formattedUsername, 'hardcore');
 
   if (hardcoreExp >= ironmanExp) {
     await submitType(player, 'hardcore');
     return 'hardcore';
   }
 
-  const ultimateExp = await getOverallExperience(formattedUsername, 'ULTIMATE_IRONMAN');
+  const ultimateExp = await getOverallExperience(formattedUsername, 'ultimate');
 
   if (ultimateExp >= ironmanExp) {
     await submitType(player, 'ultimate');
@@ -400,7 +406,7 @@ async function getCMLHistory(username, time) {
 /**
  * Fetches the player data from the Hiscores API.
  */
-async function getHiscoresData(username, type = 'NORMAL') {
+async function getHiscoresData(username, type = 'regular') {
   const proxy = getNextProxy();
   const URL = `${OSRS_HISCORES[type]}?player=${username}`;
 
@@ -434,5 +440,3 @@ exports.findById = findById;
 exports.findOrCreate = findOrCreate;
 exports.findAllOrCreate = findAllOrCreate;
 exports.findAll = findAll;
-exports.getCMLHistory = getCMLHistory;
-exports.getHiscoresData = getHiscoresData;


### PR DESCRIPTION
- Determines a player's type before first tracking it
- Fetches hiscores data from the correct player type endpoint
- Removes unnecessary job

Fixes #79 