### PR TITLE
Fix search input icon overflow

### DIFF
--- a/app/src/components/NavigationBar/NavigationBar.scss
+++ b/app/src/components/NavigationBar/NavigationBar.scss
@@ -93,7 +93,7 @@
         .text-input {
           border: 1px solid $gray-12;
           padding: 6px 9px;
-          width: 135px;
+          min-width: 135px;
         }
 
         .nav-links__item {

--- a/app/src/components/TextInput/TextInput.scss
+++ b/app/src/components/TextInput/TextInput.scss
@@ -13,7 +13,6 @@
     border: none;
     padding: 0;
     margin: 0;
-    width: 100%;
     color: white;
     font-family: 'Lato';
     font-size: 0.9em;

--- a/app/src/components/TextInput/TextInput.scss
+++ b/app/src/components/TextInput/TextInput.scss
@@ -16,6 +16,7 @@
     color: white;
     font-family: 'Lato';
     font-size: 0.9em;
+    flex-grow: 1;
 
     &:active,
     &:focus {


### PR DESCRIPTION
Fixes the search input icon overflowing in Firefox. This issue seems to be only for Firefox for me.

## Current behavior
![image](https://user-images.githubusercontent.com/14054353/81690259-56f43080-945b-11ea-9e9c-fd52c7a51ca8.png)

## This fix
![image](https://user-images.githubusercontent.com/14054353/81690287-5d82a800-945b-11ea-82b7-cc9739d887a7.png)
