### PR TITLE
Fix ironmen rank deltas 

### DIFF
--- a/app/src/pages/Player/Player.scss
+++ b/app/src/pages/Player/Player.scss
@@ -59,6 +59,25 @@
     .chart__container {
       margin-bottom: 26px;
     }
+
+    .deltas-warning {
+      background: none;
+      border-radius: $border-radius;
+      padding: 10px;
+      border: 1px dashed #f4f79e;
+      font-size: 0.8em;
+      margin-bottom: 24px;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      line-height: 1.6em;
+
+      img {
+        filter: brightness(4);
+        opacity: 0.6;
+        margin-right: 10px;
+      }
+    }
   }
 }
 

--- a/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
+++ b/app/src/pages/Player/components/PlayerDeltasTable/PlayerDeltasTable.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import Table from '../../../../components/Table';
 import NumberLabel from '../../../../components/NumberLabel';
@@ -151,17 +152,32 @@ function PlayerDeltasTable({ deltas, period, metricType, highlightedMetric, onMe
     return null;
   }
 
-  const [rows, columns] = getTableData(deltas[period].data, metricType);
+  const { data } = deltas[period];
+
+  const [rows, columns] = getTableData(data, metricType);
   const highlightedIndex = rows.map(r => r.metric).indexOf(highlightedMetric);
 
+  const warning = _.filter(data, ({ rank }) => rank.start !== rank.end && rank.delta === 0).length > 0;
+
   return (
-    <Table
-      rows={rows}
-      columns={columns}
-      onRowClicked={onRowClicked}
-      highlightedIndex={highlightedIndex}
-      clickable
-    />
+    <>
+      {warning && (
+        <div className="deltas-warning">
+          <img src="/img/icons/warn_orange.svg" alt="" />
+          <span>
+            If your skill ranks wrongfuly show 0 gained, don&apos;t worry, this was caused by a bug and
+            it will go away on its own within a few days/weeks.
+          </span>
+        </div>
+      )}
+      <Table
+        rows={rows}
+        columns={columns}
+        onRowClicked={onRowClicked}
+        highlightedIndex={highlightedIndex}
+        clickable
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
Because of #79, I previously had to invalidate (-1) all ironmen ranks. This caused rank deltas to be very high for these affected players.

This issue is now fixed but will take a few days/weeks to propagate (as those incorrect snapshots go "out of circulation").

**However for visual clarity, I made sure invalid rank deltas show up as "0", and added a warning on the affected players' pages.**