### PR TITLE
Fix (restore) initial values syncing

### DIFF
--- a/server/src/api/hooks.js
+++ b/server/src/api/hooks.js
@@ -4,7 +4,10 @@ const jobs = require('./jobs');
 function setup() {
   Snapshot.afterCreate(({ playerId }) => {
     jobs.add('SyncPlayerAchievements', { playerId });
-    jobs.add('SyncPlayerRecords', { playerId });
+    jobs.add('SyncPlayerInitialValues', { playerId });
+
+    // Delay this to ensure SyncPlayerInitialValues runs first
+    jobs.add('SyncPlayerRecords', { playerId }, { delay: 10000 });
   });
 
   Snapshot.afterBulkCreate(snapshots => {

--- a/server/src/api/jobs/instances/SyncPlayerInitialValues.js
+++ b/server/src/api/jobs/instances/SyncPlayerInitialValues.js
@@ -1,0 +1,9 @@
+const deltaService = require('../../modules/deltas/delta.service');
+
+module.exports = {
+  key: 'SyncPlayerInitialValues',
+  async handle({ data }) {
+    const { playerId } = data;
+    await deltaService.syncInitialValues(playerId);
+  }
+};

--- a/server/src/api/jobs/instances/index.js
+++ b/server/src/api/jobs/instances/index.js
@@ -5,6 +5,7 @@ const SyncPlayerAchievements = require('./SyncPlayerAchievements');
 const AddToGroupCompetitions = require('./AddToGroupCompetitions');
 const RemoveFromGroupCompetitions = require('./RemoveFromGroupCompetitions');
 const ReevaluatePlayerAchievements = require('./ReevaluatePlayerAchievements');
+const SyncPlayerInitialValues = require('./SyncPlayerInitialValues');
 
 module.exports = {
   ImportPlayer,
@@ -13,5 +14,6 @@ module.exports = {
   SyncPlayerAchievements,
   AddToGroupCompetitions,
   RemoveFromGroupCompetitions,
-  ReevaluatePlayerAchievements
+  ReevaluatePlayerAchievements,
+  SyncPlayerInitialValues
 };


### PR DESCRIPTION
The initial values table stopped being updated since #137.

This adds a new job for syncing a player's initial values post-update.