### PR TITLE
Fix width of table list with no results

### DIFF
--- a/app/src/components/TableList/TableList.jsx
+++ b/app/src/components/TableList/TableList.jsx
@@ -33,7 +33,7 @@ function TableList({ uniqueKeySelector, rows, columns, onRowClicked, clickable }
           })
         ) : (
           <tr className="-empty">
-            <td>No results found</td>
+            <td colSpan={columns.length}>No results found</td>
           </tr>
         )}
       </tbody>


### PR DESCRIPTION
Fixes that the `TableList` component does not fill the column width.

## Current behaviour
![image](https://user-images.githubusercontent.com/14054353/82713169-51cc8800-9c8a-11ea-9d31-01a968be34b5.png)

## This fix
![image](https://user-images.githubusercontent.com/14054353/82713227-8c362500-9c8a-11ea-8be1-2fe7b3174296.png)

