### PR TITLE
Add competitions list to Group page

### DIFF
--- a/app/src/components/Tabs/Tabs.scss
+++ b/app/src/components/Tabs/Tabs.scss
@@ -3,6 +3,7 @@
 
 .tab-bar {
   @extend %panel;
+  @extend %block-text-selection;
   padding: 10px 15px;
   display: flex;
   flex-direction: row;

--- a/app/src/config/routing.js
+++ b/app/src/config/routing.js
@@ -56,7 +56,7 @@ export const ROUTES = [
     component: EditGroupPage
   },
   {
-    path: '/groups/:id',
+    path: '/groups/:id/:section?',
     component: GroupPage
   },
   {

--- a/app/src/pages/Group/Group.scss
+++ b/app/src/pages/Group/Group.scss
@@ -28,6 +28,16 @@
     }
   }
 
+  .group__content {
+    .tab-bar {
+      margin-bottom: 24px;
+    }
+
+    .table-list {
+      margin-top: -10px;
+    }
+  }
+
   .group__widgets {
     margin-top: 10px;
 

--- a/app/src/pages/Group/components/GroupCompetitionsTable/GroupCompetitionsTable.jsx
+++ b/app/src/pages/Group/components/GroupCompetitionsTable/GroupCompetitionsTable.jsx
@@ -1,0 +1,75 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import _ from 'lodash';
+import TableList from '../../../../components/TableList';
+import StatusDot from '../../../../components/StatusDot';
+import { getMetricIcon } from '../../../../utils';
+
+function convertStatus(status) {
+  switch (status) {
+    case 'upcoming':
+      return 'NEUTRAL';
+    case 'ongoing':
+      return 'POSITIVE';
+    case 'finished':
+      return 'NEGATIVE';
+    default:
+      return null;
+  }
+}
+
+const TABLE_CONFIG = {
+  uniqueKey: row => row.id,
+  columns: [
+    {
+      key: 'metric',
+      width: 30,
+      transform: value => <img src={getMetricIcon(value)} alt="" />
+    },
+    { key: 'title', className: () => '-primary' },
+    {
+      key: 'status',
+      className: () => '-break-small',
+      transform: (value, row) => (
+        <div className="status-cell">
+          <StatusDot status={convertStatus(value)} />
+          <span>{row && row.countdown}</span>
+        </div>
+      )
+    },
+    {
+      key: 'participantCount',
+      className: () => '-break-medium',
+      transform: val => `${val} participants`
+    }
+  ]
+};
+
+function GroupCompetitionsTable({ competitions }) {
+  const router = useHistory();
+  const order = ['ongoing', 'upcoming', 'finished'];
+  const rows = competitions ? _.sortBy(competitions, c => _.indexOf(order, c.status)) : [];
+
+  const handleRowClicked = index => {
+    router.push(`/competitions/${rows[index].id}`);
+  };
+
+  const onRowClicked = useCallback(handleRowClicked, [router, competitions]);
+
+  return (
+    <TableList
+      uniqueKeySelector={TABLE_CONFIG.uniqueKey}
+      rows={rows}
+      columns={TABLE_CONFIG.columns}
+      clickable
+      onRowClicked={onRowClicked}
+    />
+  );
+}
+
+GroupCompetitionsTable.propTypes = {
+  competitions: PropTypes.arrayOf(PropTypes.shape).isRequired
+};
+
+export default React.memo(GroupCompetitionsTable);

--- a/app/src/pages/Group/components/GroupCompetitionsTable/index.js
+++ b/app/src/pages/Group/components/GroupCompetitionsTable/index.js
@@ -1,0 +1,3 @@
+import GroupCompetitionsTable from './GroupCompetitionsTable';
+
+export default GroupCompetitionsTable;

--- a/server/src/api/modules/groups/group.service.js
+++ b/server/src/api/modules/groups/group.service.js
@@ -213,7 +213,7 @@ async function getMembersList(id) {
   return memberships
     .map(({ player, role }) => ({ ...player.toJSON(), role }))
     .map(member => ({ ...member, overallExperience: experienceMap[member.id] || 0 }))
-    .sort((a, b) => b.overallExperience - a.overallExperience);
+    .sort((a, b) => a.role.localeCompare(b.role));
 }
 
 async function create(name, members) {


### PR DESCRIPTION
Resolves #120 

- Sorts the group's member list by role by default (you can still sort by overall exp by clicking on the overall exp column)
- Adds competitions list to the Group page

![image](https://user-images.githubusercontent.com/3278148/82739922-d75c4080-9d3b-11ea-9cd4-ccbeb3ba55c9.png)
