### PR TITLE
fix group table overflow arrow and add/fix labels

### DIFF
--- a/app/src/pages/Competition/components/CompetitionTable/CompetitionTable.jsx
+++ b/app/src/pages/Competition/components/CompetitionTable/CompetitionTable.jsx
@@ -42,13 +42,13 @@ function CompetitionTable({ competition, updatingUsernames, onUpdateClicked, isL
       {
         key: 'start',
         transform: val => <NumberLabel value={val} />,
-        className: () => '-break-large',
+        className: () => '-break-small',
         get: row => (row.progress ? row.progress.start : 0)
       },
       {
         key: 'end',
         transform: val => <NumberLabel value={val} />,
-        className: () => '-break-large',
+        className: () => '-break-small',
         get: row => (row.progress ? row.progress.end : 0)
       },
       {

--- a/app/src/pages/Competition/components/CompetitionTable/CompetitionTable.jsx
+++ b/app/src/pages/Competition/components/CompetitionTable/CompetitionTable.jsx
@@ -31,6 +31,7 @@ function CompetitionTable({ competition, updatingUsernames, onUpdateClicked, isL
       },
       {
         key: 'displayName',
+        label: 'Name',
         className: () => '-primary',
         transform: (value, row) => (
           <Link to={`/players/${row.id}`}>

--- a/app/src/pages/Group/components/MembersTable/MembersTable.jsx
+++ b/app/src/pages/Group/components/MembersTable/MembersTable.jsx
@@ -21,6 +21,7 @@ function MembersTable({ members, isLoading }) {
       },
       {
         key: 'displayName',
+        label: 'Display name',
         className: () => '-primary',
         transform: (value, row) => (
           <Link to={`/players/${row.id}`}>
@@ -41,7 +42,7 @@ function MembersTable({ members, isLoading }) {
       {
         key: 'updatedAt',
         label: 'Last updated',
-        className: () => '-break-large',
+        className: () => '-break-small',
         transform: value => `${durationBetween(value, new Date(), 2, true)} ago`
       }
     ]

--- a/app/src/pages/Group/components/MembersTable/MembersTable.jsx
+++ b/app/src/pages/Group/components/MembersTable/MembersTable.jsx
@@ -21,7 +21,7 @@ function MembersTable({ members, isLoading }) {
       },
       {
         key: 'displayName',
-        label: 'Display name',
+        label: 'Name',
         className: () => '-primary',
         transform: (value, row) => (
           <Link to={`/players/${row.id}`}>


### PR DESCRIPTION
Fixes:
```
ySomicToday at 03:03
Also on mobile, the sortable table has an arrow for me (probably from a column that's hidden duo responsive design)
```

Adds label for displayName