### PR TITLE
fix css load order

### DIFF
--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from './redux/store';
+
 import 'bootstrap/dist/css/bootstrap-grid.min.css';
 import './index.scss';
+
 import App from './App';
 
 ReactDOM.render(

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-
 import store from './redux/store';
-import App from './App';
-
 import 'bootstrap/dist/css/bootstrap-grid.min.css';
 import './index.scss';
+import App from './App';
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
I noticed that there was a difference in css when using prod / build.

prod:
![https://i.imgur.com/V9pskyz.png](https://i.imgur.com/V9pskyz.png)

build:
![https://i.imgur.com/8biymk3.png](https://i.imgur.com/8biymk3.png)

This was due to "wrong" load order of css 

prod after fix:
![https://i.imgur.com/hqduWnv.png](https://i.imgur.com/hqduWnv.png)