### PR TITLE
Add clan chat field to Groups

### DIFF
--- a/app/src/pages/CreateGroup/CreateGroup.jsx
+++ b/app/src/pages/CreateGroup/CreateGroup.jsx
@@ -23,6 +23,7 @@ function CreateGroup() {
   const error = useSelector(state => getError(state));
 
   const [name, setName] = useState('');
+  const [clanChat, setClanChat] = useState('');
   const [members, setMembers] = useState([]);
   const [showingImportModal, toggleImportModal] = useState(false);
   const [showingEmptyConfirmationModal, toggleEmptyConfirmationModal] = useState(false);
@@ -31,6 +32,10 @@ function CreateGroup() {
 
   const handleNameChanged = e => {
     setName(e.target.value);
+  };
+
+  const handleClanChatChanged = e => {
+    setClanChat(e.target.value);
   };
 
   const handleAddMember = username => {
@@ -87,7 +92,7 @@ function CreateGroup() {
   };
 
   const handleSubmit = async () => {
-    const formData = { name, members };
+    const formData = { name, clanChat, members };
 
     dispatch(createGroupAction(formData)).then(a => {
       if (a && a.group) {
@@ -107,11 +112,12 @@ function CreateGroup() {
   const showEmptyConfirmationModal = useCallback(() => toggleEmptyConfirmationModal(true), []);
 
   const onNameChanged = useCallback(handleNameChanged, []);
+  const onClanChatChanged = useCallback(handleClanChatChanged, []);
   const onMemberAdded = useCallback(handleAddMember, [members]);
   const onMemberRemoved = useCallback(handleRemoveMember, [members]);
   const onMemberRoleSwitched = useCallback(handleRoleSwitch, [members]);
   const onConfirmVerification = useCallback(handleConfirmVerification, [createdId]);
-  const onSubmit = useCallback(handleSubmit, [name, members]);
+  const onSubmit = useCallback(handleSubmit, [name, clanChat, members]);
   const onSubmitMembersModal = useCallback(handleModalSubmit, []);
 
   const isEmpty = members.length === 0;
@@ -128,6 +134,11 @@ function CreateGroup() {
         <div className="form-row">
           <span className="form-row__label">Group name</span>
           <TextInput placeholder="Ex: Varrock Titans" onChange={onNameChanged} />
+        </div>
+
+        <div className="form-row">
+          <span className="form-row__label">Clan Chat</span>
+          <TextInput placeholder="Ex: titanZ" onChange={onClanChatChanged} />
         </div>
 
         <div className="form-row">

--- a/app/src/pages/EditGroup/EditGroup.jsx
+++ b/app/src/pages/EditGroup/EditGroup.jsx
@@ -21,6 +21,7 @@ function EditGroup() {
   const dispatch = useDispatch();
 
   const [name, setName] = useState('');
+  const [clanChat, setClanChat] = useState('');
   const [members, setMembers] = useState([]);
   const [showingImportModal, toggleImportModal] = useState(false);
   const [verificationCode, setVerificationCode] = useState('');
@@ -37,6 +38,7 @@ function EditGroup() {
   const populate = () => {
     if (group) {
       setName(group.name);
+      setClanChat(group.clanChat || '');
       setMembers(
         group.members.map(({ username, displayName, role }) => ({ username, displayName, role }))
       );
@@ -45,6 +47,10 @@ function EditGroup() {
 
   const handleNameChanged = e => {
     setName(e.target.value);
+  };
+
+  const handleClanChatChanged = e => {
+    setClanChat(e.target.value);
   };
 
   const handleVerificationChanged = e => {
@@ -105,7 +111,7 @@ function EditGroup() {
   };
 
   const handleSubmit = async () => {
-    const formData = { name, members, verificationCode };
+    const formData = { name, members, clanChat, verificationCode };
 
     dispatch(editGroupAction(group.id, formData)).then(a => {
       if (a && a.group) {
@@ -118,12 +124,13 @@ function EditGroup() {
   const showMembersModal = useCallback(() => toggleImportModal(true), []);
 
   const onNameChanged = useCallback(handleNameChanged, []);
+  const onClanChatChanged = useCallback(handleClanChatChanged, []);
   const onMemberAdded = useCallback(handleAddMember, [members]);
   const onMemberRemoved = useCallback(handleRemoveMember, [members]);
   const onMemberRoleSwitched = useCallback(handleRoleSwitch, [members]);
   const onVerificationChanged = useCallback(handleVerificationChanged, []);
   const onSubmitMembersModal = useCallback(handleModalSubmit, []);
-  const onSubmit = useCallback(handleSubmit, [name, members, verificationCode]);
+  const onSubmit = useCallback(handleSubmit, [name, clanChat, members, verificationCode]);
 
   // Fetch competition details, on mount
   useEffect(fetchDetails, [dispatch, id]);
@@ -145,6 +152,11 @@ function EditGroup() {
         <div className="form-row">
           <span className="form-row__label">Group name</span>
           <TextInput value={name} placeholder="Ex: Varrock Titans" onChange={onNameChanged} />
+        </div>
+
+        <div className="form-row">
+          <span className="form-row__label">Clan chat</span>
+          <TextInput placeholder="Ex: titanZ" value={clanChat} onChange={onClanChatChanged} />
         </div>
 
         <div className="form-row">

--- a/app/src/pages/Group/components/GroupInfo/GroupInfo.jsx
+++ b/app/src/pages/Group/components/GroupInfo/GroupInfo.jsx
@@ -5,10 +5,11 @@ import { formatDate } from '../../../../utils';
 import './GroupInfo.scss';
 
 function formatData(group) {
-  const { id, members, createdAt, updatedAt } = group;
+  const { id, members, clanChat, createdAt, updatedAt } = group;
 
   return [
     { key: 'Id', value: id },
+    { key: 'Clan chat', value: clanChat || 'Unknown' },
     { key: 'Members', value: members ? members.length : 'Unknown' },
     { key: 'Created at', value: formatDate(createdAt, 'DD MMM YYYY, HH:mm') },
     { key: 'Last updated at', value: formatDate(updatedAt, 'DD MMM YYYY, HH:mm') }

--- a/app/src/redux/modules/groups/actions/create.js
+++ b/app/src/redux/modules/groups/actions/create.js
@@ -30,13 +30,13 @@ function createGroupFailure(error) {
   };
 }
 
-export default function createGroup({ name, members }) {
+export default function createGroup({ name, clanChat, members }) {
   return dispatch => {
     dispatch(createGroupRequest());
 
     const url = `${BASE_API_URL}/groups/`;
 
-    const body = { name, members };
+    const body = { name, clanChat, members };
 
     return axios
       .post(url, body)

--- a/app/src/redux/modules/groups/actions/edit.js
+++ b/app/src/redux/modules/groups/actions/edit.js
@@ -38,6 +38,7 @@ export default function editGroup(id, requestBody) {
 
     const body = {
       name: requestBody.name,
+      clanChat: requestBody.clanChat,
       members: requestBody.members,
       verificationCode: requestBody.verificationCode
     };

--- a/docs/src/configs/docs/groups/endpoints.js
+++ b/docs/src/configs/docs/groups/endpoints.js
@@ -40,6 +40,7 @@ export default [
           {
             id: 1,
             name: 'Hexis',
+            clanChat: null,
             createdAt: '2020-04-18T08:37:24.190Z',
             updatedAt: '2020-04-18T08:37:24.190Z',
             memberCount: 3
@@ -47,6 +48,7 @@ export default [
           {
             id: 2,
             name: 'RSPT',
+            clanChat: 'rspt',
             createdAt: '2020-04-18T08:45:28.726Z',
             updatedAt: '2020-04-18T08:47:50.870Z',
             memberCount: 21
@@ -54,6 +56,7 @@ export default [
           {
             id: 4,
             name: 'Varrock Titans',
+            clanChat: 'Vrck Titans',
             createdAt: '2020-04-18T09:01:10.630Z',
             updatedAt: '2020-04-18T09:07:00.915Z',
             memberCount: 13
@@ -79,6 +82,7 @@ export default [
         body: {
           id: 4,
           name: 'RSPT',
+          clanChat: 'rspt',
           createdAt: '2020-04-18T09:01:10.630Z',
           updatedAt: '2020-04-18T09:07:00.915Z'
         }
@@ -370,6 +374,7 @@ export default [
     ],
     body: {
       name: 'Falador Knights',
+      clanChat: 'fallyK',
       members: [
         { username: 'Psikoi', role: 'leader' },
         { username: 'Zezima', role: 'leader' },
@@ -383,6 +388,7 @@ export default [
         body: {
           id: 23,
           name: 'Falador Knights',
+          clanChat: 'fallyK',
           verificationCode: '107-719-861',
           updatedAt: '2020-04-23T01:53:26.079Z',
           createdAt: '2020-04-23T01:53:26.079Z',
@@ -469,6 +475,7 @@ export default [
     ],
     body: {
       name: 'Some new name',
+      clanChat: 'fallyK',
       verificationCode: '842-225-748',
       members: ['Psikoi', 'Zezima']
     },
@@ -478,6 +485,7 @@ export default [
         body: {
           id: 2,
           name: 'Some new name',
+          clanChat: 'fallyK',
           createdAt: '2020-04-18T08:45:28.726Z',
           updatedAt: '2020-04-18T15:30:41.380Z',
           members: [
@@ -792,9 +800,7 @@ export default [
     comments: [
       {
         type: 'warning',
-        content:
-          "This action will perform a soft-update, meaning it won't \
-          import the player from CML or determine it's type."
+        content: "This action will perform a soft-update, meaning it won't import the player from CML."
       },
       {
         type: 'warning',

--- a/docs/src/configs/docs/groups/entities.js
+++ b/docs/src/configs/docs/groups/entities.js
@@ -1,6 +1,6 @@
 export default [
   {
-    name: 'Competition',
+    name: 'Group',
     description: '',
     structure: [
       {
@@ -12,6 +12,11 @@ export default [
         field: 'name',
         type: 'string',
         description: "The group's unique name (1-30 characters)."
+      },
+      {
+        field: 'clanChat',
+        type: 'string',
+        description: "The group's clan chat (1-20 characters) (Optional)."
       },
       {
         field: 'verificationHash',

--- a/server/__tests__/integration/group.test.js
+++ b/server/__tests__/integration/group.test.js
@@ -37,10 +37,13 @@ describe('Group API', () => {
     });
 
     test('Create valid group (no members)', async done => {
-      const response = await request.post('/api/groups').send({ name: ' Some Group_' });
+      const response = await request
+        .post('/api/groups')
+        .send({ name: ' Some Group_', clanChat: ' Test ' });
 
       expect(response.status).toBe(201);
       expect(response.body.name).toMatch('Some Group');
+      expect(response.body.clanChat).toMatch('Test');
 
       TEST_DATA.noMembers = response.body;
 
@@ -209,6 +212,18 @@ describe('Group API', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.name).toBe('WISE OLD MAN');
+
+      done();
+    });
+
+    test('Edit (clan chat)', async done => {
+      const response = await request.put(`/api/groups/${TEST_DATA.noMembers.id}`).send({
+        clanChat: 'TheBois ',
+        verificationCode: TEST_DATA.noMembers.verificationCode
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.clanChat).toBe('TheBois');
 
       done();
     });

--- a/server/src/api/modules/groups/group.controller.js
+++ b/server/src/api/modules/groups/group.controller.js
@@ -67,9 +67,9 @@ async function listMembers(req, res, next) {
 
 async function createGroup(req, res, next) {
   try {
-    const { name, members } = req.body;
+    const { name, clanChat, members } = req.body;
 
-    const group = await service.create(name, members);
+    const group = await service.create(name, clanChat, members);
     res.status(201).json(group);
   } catch (e) {
     next(e);
@@ -79,9 +79,9 @@ async function createGroup(req, res, next) {
 async function editGroup(req, res, next) {
   try {
     const { id } = req.params;
-    const { name, verificationCode, members } = req.body;
+    const { name, clanChat, members, verificationCode } = req.body;
 
-    const group = await service.edit(id, name, verificationCode, members);
+    const group = await service.edit(id, name, clanChat, verificationCode, members);
     res.json(group);
   } catch (e) {
     next(e);

--- a/server/src/api/modules/groups/group.model.js
+++ b/server/src/api/modules/groups/group.model.js
@@ -20,6 +20,9 @@ module.exports = (sequelize, DataTypes) => {
         }
       }
     },
+    clanChat: {
+      type: DataTypes.STRING(20)
+    },
     verificationCode: {
       type: DataTypes.VIRTUAL,
       allowNull: false

--- a/server/src/api/modules/groups/group.service.js
+++ b/server/src/api/modules/groups/group.service.js
@@ -222,7 +222,7 @@ async function create(name, clanChat, members) {
   }
 
   const sanitizedName = sanitizeName(name);
-  const sanitizedClanChat = clanChat && playerService.sanitize(clanChat);
+  const sanitizedClanChat = clanChat && clanChat.length ? playerService.sanitize(clanChat) : null;
 
   if (await Group.findOne({ where: { name: sanitizedName } })) {
     throw new BadRequestError(`Group name '${sanitizedName}' is already taken.`);
@@ -329,9 +329,12 @@ async function edit(id, name, clanChat, verificationCode, members) {
   }
 
   if (name || clanChat) {
+    const sanitizedName = name && sanitizeName(name);
+    const sanitizedClanChat = clanChat && clanChat.length ? playerService.sanitize(clanChat) : null;
+
     await group.update({
-      name: name && sanitizeName(name),
-      clanChat: clanChat && playerService.sanitize(clanChat)
+      name: sanitizedName,
+      clanChat: sanitizedClanChat
     });
   }
 

--- a/server/src/api/modules/players/player.service.js
+++ b/server/src/api/modules/players/player.service.js
@@ -503,6 +503,7 @@ async function getHiscoresNames(username) {
 }
 
 exports.standardize = standardize;
+exports.sanitize = sanitize;
 exports.isValidUsername = isValidUsername;
 exports.shouldUpdate = shouldUpdate;
 exports.shouldImport = shouldImport;

--- a/server/src/database/migrations/20200525192819-add-clan-chat-groups.js
+++ b/server/src/database/migrations/20200525192819-add-clan-chat-groups.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('groups', 'clanChat', {
+      type: Sequelize.STRING(20)
+    });
+  },
+
+  down: queryInterface => {
+    return queryInterface.removeColumn('groups', 'clanChat');
+  }
+};


### PR DESCRIPTION
- Adds clanChat column to group model/table
- Adds clanChat as a parameter to the group's create and edit endpoints
- Updates the group integration tests
- Updates the group API documentation
- Adds Clan Chat information on the group's page
- Adds Clan Chat inputs in the group create/edit forms