### PR TITLE
Add chart snapshot distribution algorithm

### DIFF
--- a/app/src/components/LineChart/LineChart.jsx
+++ b/app/src/components/LineChart/LineChart.jsx
@@ -73,7 +73,35 @@ function getConfig(datasets, invertYAxis) {
   };
 }
 
-function LineChart({ datasets, invertYAxis }) {
+function renderDistributionLabel(distribution, callback) {
+  if (!distribution || distribution.before <= 30) {
+    return null;
+  }
+
+  const { enabled, after, before } = distribution;
+
+  if (enabled) {
+    return (
+      <span className="distribution-label">
+        {`Showing only ${after} out of ${before} snapshots for easier viewing.`}
+        <button type="button" onClick={callback}>
+          Show all
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <span className="distribution-label">
+      {`Showing ${before} snapshots. Are these hard to read?`}
+      <button type="button" onClick={callback}>
+        Click to smoothen the chart
+      </button>
+    </span>
+  );
+}
+
+function LineChart({ datasets, distribution, onDistributionChanged, invertYAxis }) {
   const hasEnoughData = datasets.filter(d => d.data.length > 1).length > 0;
 
   const chartObjectRef = useRef(null);
@@ -106,18 +134,25 @@ function LineChart({ datasets, invertYAxis }) {
 
   return (
     <div className="chart__container">
+      {renderDistributionLabel(distribution, onDistributionChanged)}
       <canvas id="line-chart" ref={chartRef} />
     </div>
   );
 }
 
 LineChart.defaultProps = {
-  invertYAxis: false
+  invertYAxis: false,
+  distribution: undefined,
+  onDistributionChanged: undefined
 };
 
 LineChart.propTypes = {
   // The datasets to display, each set will be a line in the graph
   datasets: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+
+  distribution: PropTypes.shape(PropTypes.shape()),
+
+  onDistributionChanged: PropTypes.func,
 
   // If true, the Y axis will be inverted (Useful for displaying rank progress)
   invertYAxis: PropTypes.bool

--- a/app/src/components/LineChart/LineChart.scss
+++ b/app/src/components/LineChart/LineChart.scss
@@ -2,7 +2,7 @@
 
 .chart__container {
   @extend %panel;
-  padding: 30px;
+  padding: 20px;
 
   .not-enough-data {
     color: $gray-60;
@@ -11,5 +11,28 @@
     display: block;
     width: 100%;
     padding: 100px 0;
+  }
+
+  .distribution-label {
+    display: block;
+    text-align: center;
+    margin-bottom: 20px;
+    font-size: 0.7em;
+    color: $gray-60;
+
+    button {
+      background: none;
+      border: none;
+      font-size: 1em;
+      color: white;
+      padding: 0;
+      margin: 0;
+      margin-left: 5px;
+      cursor: pointer;
+
+      &:hover {
+        opacity: 0.7;
+      }
+    }
   }
 }

--- a/app/src/pages/Player/Player.jsx
+++ b/app/src/pages/Player/Player.jsx
@@ -132,6 +132,7 @@ function Player() {
   const selectedPeriod = getSelectedPeriod(location);
   const selectedMetric = getSelectedMetric(selectedMetricType, location);
 
+  const [isReducedChart, setIsReducedChart] = useState(true);
   const [isTracking, setIsTracking] = useState(false);
   const [selectedLevelType, setSelectedLevelType] = useState('regular');
 
@@ -149,11 +150,11 @@ function Player() {
   const deltasPeriodIndex = PERIOD_OPTIONS.findIndex(o => o.value === selectedPeriod);
 
   const experienceChartData = useSelector(state =>
-    getChartData(state, id, selectedPeriod, selectedMetric, getMeasure(selectedMetric))
+    getChartData(state, id, selectedPeriod, selectedMetric, getMeasure(selectedMetric), isReducedChart)
   );
 
   const rankChartData = useSelector(state =>
-    getChartData(state, id, selectedPeriod, selectedMetric, 'rank')
+    getChartData(state, id, selectedPeriod, selectedMetric, 'rank', isReducedChart)
   );
 
   const trackPlayer = async () => {
@@ -221,6 +222,10 @@ function Player() {
     router.push(getNextUrl({ metricType: e.value }));
   };
 
+  const toggleReducedChart = () => {
+    setIsReducedChart(val => !val);
+  };
+
   const handleOptionSelected = async option => {
     if (option.value === 'assertType') {
       await dispatch(assertPlayerTypeAction(player.username, player.id));
@@ -235,6 +240,7 @@ function Player() {
     dispatch(fetchDeltasAction({ playerId: id }));
   };
 
+  const onToggleReducedChart = useCallback(toggleReducedChart, []);
   const onLevelTypeSelected = useCallback(handleLevelTypeSelected, [setSelectedLevelType]);
   const onOptionSelected = useCallback(handleOptionSelected, [player]);
   const onUpdateButtonClicked = useCallback(trackPlayer, [player]);
@@ -370,8 +376,17 @@ function Player() {
         {selectedTabIndex === 1 && (
           <>
             <div className="col-lg-6 col-md-12">
-              <LineChart datasets={experienceChartData} />
-              <LineChart datasets={rankChartData} invertYAxis />
+              <LineChart
+                datasets={experienceChartData.datasets}
+                distribution={experienceChartData.distribution}
+                onDistributionChanged={onToggleReducedChart}
+              />
+              <LineChart
+                datasets={rankChartData.datasets}
+                distribution={experienceChartData.distribution}
+                onDistributionChanged={onToggleReducedChart}
+                invertYAxis
+              />
             </div>
             <div className="col-lg-6 col-md-12">
               <PlayerDeltasInfo

--- a/app/src/redux/selectors/competitions.js
+++ b/app/src/redux/selectors/competitions.js
@@ -63,7 +63,7 @@ export const getChartData = (state, id) => {
 
     datasets.push({
       borderColor: COLORS[i],
-      pointBorderWidth: 4,
+      pointBorderWidth: 1,
       label: participant.username,
       data: filteredPoints,
       fill: false

--- a/app/src/utils/algorithms.js
+++ b/app/src/utils/algorithms.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+export function distribute(snapshots, limit) {
+  if (snapshots.length <= limit) {
+    return snapshots;
+  }
+
+  const startSnapshot = snapshots[snapshots.length - 1];
+  const endSnapshot = snapshots[0];
+
+  const startTime = startSnapshot.createdAt.getTime();
+  const timeSliceSize = Math.round((endSnapshot.createdAt - startSnapshot.createdAt) / limit);
+  const selected = [];
+
+  for (let i = 0; i < limit; i++) {
+    const startTimestamp = startTime + i * timeSliceSize;
+    const endTimestamp = startTime + (i + 1) * timeSliceSize;
+    const midTimestamp = startTimestamp + (endTimestamp - startTimestamp) / 2;
+
+    const filtered = snapshots.filter(s => s.createdAt >= startTimestamp && s.createdAt <= endTimestamp);
+
+    if (filtered && filtered.length > 0) {
+      const best = filtered.reduce((a, b) => {
+        return Math.abs(b.createdAt - midTimestamp) < Math.abs(a.createdAt - midTimestamp) ? b : a;
+      });
+
+      if (best) {
+        selected.push(best);
+      }
+    }
+  }
+
+  return _.uniqBy([startSnapshot, ...selected, endSnapshot], s => s.createdAt.getTime());
+}

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -3,3 +3,4 @@ export * from './levels';
 export * from './player';
 export * from './metrics';
 export * from './strings';
+export * from './algorithms';


### PR DESCRIPTION
Closes #80 
Closes #150 

- Adds the ability to reduce/expand the snapshot density in the player "gained" charts
- Reduces the point width of competition charts from 4px to 1px (makes it easier to read)

![image](https://i.gyazo.com/34829788bc867ec6ae0d53d9032279de.gifg)
